### PR TITLE
Backport: Fix `wp-cli` to bring `$cp_version` into scope

### DIFF
--- a/src/license.txt
+++ b/src/license.txt
@@ -1,6 +1,6 @@
 ClassicPress - Web publishing software
 
-Copyright © 2018-2023 ClassicPress and contributors
+Copyright © 2018-2024 ClassicPress and contributors
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ and
 
   WordPress - Web publishing software
 
-  Copyright 2003-2023 by the WordPress contributors
+  Copyright 2003-2024 by the WordPress contributors
 
   WordPress is released under the GPL
 

--- a/src/wp-includes/class-fix-wpcli.php
+++ b/src/wp-includes/class-fix-wpcli.php
@@ -19,7 +19,21 @@ class Fix_WPCLI {
 	 * @since CP-1.5.0
 	 */
 	public function __construct() {
+		WP_CLI::add_hook( 'after_wp_load', array( __CLASS__, 'bring_cp_version_in_scope' ) );
 		WP_CLI::add_hook( 'before_invoke:core check-update', array( __CLASS__, 'correct_core_check_update' ) );
+	}
+
+	/**
+	 * Put $cp_version into scope.
+	 *
+	 * @since CP-2.0.0
+	 */
+	public static function bring_cp_version_in_scope() {
+		// Put $cp_version into scope.
+		if ( ! isset( $GLOBALS['cp_version'] ) ) {
+			global $cp_version;
+			require ABSPATH . WPINC . '/version.php';
+		}
 	}
 
 	/**
@@ -28,6 +42,8 @@ class Fix_WPCLI {
 	 * @since CP-1.5.0
 	 */
 	public static function correct_core_check_update() {
+		// Put $cp_version into scope.
+		global $cp_version;
 
 		// Check for updates. Bail on error.
 		// When playing with versions, an empty array is returned if it's not on api.
@@ -70,12 +86,6 @@ class Fix_WPCLI {
 		$minor = preg_match( '/ --minor */', $current_command );
 
 		$major = preg_match( '/ --major */', $current_command );
-
-		// Put $cp_version into scope.
-		if ( ! isset( $GLOBALS['cp_version'] ) ) {
-			global $cp_version;
-			require ABSPATH . WPINC . '/version.php';
-		}
 
 		// Prepare output array.
 		$table_output = array();

--- a/src/wp-includes/class-fix-wpcli.php
+++ b/src/wp-includes/class-fix-wpcli.php
@@ -26,7 +26,7 @@ class Fix_WPCLI {
 	/**
 	 * Put $cp_version into scope.
 	 *
-	 * @since CP-2.0.0
+	 * @since CP-1.7.3
 	 */
 	public static function bring_cp_version_in_scope() {
 		// Put $cp_version into scope.

--- a/src/wp-includes/class-fix-wpcli.php
+++ b/src/wp-includes/class-fix-wpcli.php
@@ -19,17 +19,17 @@ class Fix_WPCLI {
 	 * @since CP-1.5.0
 	 */
 	public function __construct() {
-		WP_CLI::add_hook( 'after_wp_load', array( __CLASS__, 'bring_cp_version_in_scope' ) );
+		WP_CLI::add_hook( 'after_wp_load', array( __CLASS__, 'add_cp_version_to_scope' ) );
 		WP_CLI::add_hook( 'before_invoke:core check-update', array( __CLASS__, 'correct_core_check_update' ) );
 	}
 
 	/**
-	 * Put $cp_version into scope.
+	 * Add $cp_version to scope.
 	 *
 	 * @since CP-1.7.3
 	 */
-	public static function bring_cp_version_in_scope() {
-		// Put $cp_version into scope.
+	public static function add_cp_version_to_scope() {
+		// Add $cp_version to scope.
 		if ( ! isset( $GLOBALS['cp_version'] ) ) {
 			global $cp_version;
 			require ABSPATH . WPINC . '/version.php';
@@ -42,7 +42,7 @@ class Fix_WPCLI {
 	 * @since CP-1.5.0
 	 */
 	public static function correct_core_check_update() {
-		// Put $cp_version into scope.
+		// Add $cp_version to scope.
 		global $cp_version;
 
 		// Check for updates. Bail on error.
@@ -122,7 +122,6 @@ class Fix_WPCLI {
 		// Exit to prevent the core check-update command to continue his work.
 		exit;
 	}
-
 }
 
 new Fix_WPCLI();


### PR DESCRIPTION
See [PR1322 on ClassicPress (v2)](https://github.com/ClassicPress/ClassicPress/pull/1322).
