### PR TITLE
Fix WP version and release notes

### DIFF
--- a/src/license.txt
+++ b/src/license.txt
@@ -1,6 +1,6 @@
 ClassicPress - Web publishing software
 
-Copyright © 2018-2023 ClassicPress and contributors
+Copyright © 2018-2024 ClassicPress and contributors
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -31,7 +31,7 @@ and
 
   WordPress - Web publishing software
 
-  Copyright 2003-2023 by the WordPress contributors
+  Copyright 2003-2024 by the WordPress contributors
 
   WordPress is released under the GPL
 

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -164,7 +164,7 @@ require ABSPATH . 'wp-admin/admin-header.php';
 				printf(
 					/* translators: %s: HelpHub URL */
 					__( 'For more information, see <a href="%s">the blog post</a>.' ),
-					esc_url( __( 'https://wordpress.org/news/2024/01/wordpress-6-4-3-maintenance-and-security-release/' ) ),
+					esc_url( __( 'https://wordpress.org/news/2024/01/wordpress-6-4-3-maintenance-and-security-release/' ) )
 				);
 				?>
 			</p>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -157,6 +157,22 @@ require ABSPATH . 'wp-admin/admin-header.php';
 				printf(
 					/* translators: %s: WordPress version number */
 					__( '<strong>Version %s</strong> addressed some security issues.' ),
+					'4.9.25'
+				);
+				?>
+				<?php
+				printf(
+					/* translators: %s: HelpHub URL */
+					__( 'For more information, see <a href="%s">the blog post</a>.' ),
+					esc_url( __( 'https://wordpress.org/news/2024/01/wordpress-6-4-3-maintenance-and-security-release/' ) ),
+				);
+				?>
+			</p>
+			<p>
+				<?php
+				printf(
+					/* translators: %s: WordPress version number */
+					__( '<strong>Version %s</strong> addressed some security issues.' ),
 					'4.9.24'
 				);
 				?>

--- a/src/wp-admin/about.php
+++ b/src/wp-admin/about.php
@@ -156,7 +156,7 @@ require ABSPATH . 'wp-admin/admin-header.php';
 				<?php
 				printf(
 					/* translators: %s: WordPress version number */
-					__( '<strong>Version %s</strong> addressed some security issues.' ),
+					__( '<strong>WordPress Version %s</strong> addressed some security issues.' ),
 					'4.9.25'
 				);
 				?>
@@ -172,7 +172,7 @@ require ABSPATH . 'wp-admin/admin-header.php';
 				<?php
 				printf(
 					/* translators: %s: WordPress version number */
-					__( '<strong>Version %s</strong> addressed some security issues.' ),
+					__( '<strong>WordPress Version %s</strong> addressed some security issues.' ),
 					'4.9.24'
 				);
 				?>

--- a/src/wp-admin/includes/class-file-upload-upgrader.php
+++ b/src/wp-admin/includes/class-file-upload-upgrader.php
@@ -92,7 +92,7 @@ class File_Upload_Upgrader {
 				}
 			}
 
-			$this->filename = $_FILES[$form]['name'];
+			$this->filename = $_FILES[ $form ]['name'];
 			$this->package  = $file['file'];
 
 			// Construct the object array

--- a/src/wp-admin/includes/schema.php
+++ b/src/wp-admin/includes/schema.php
@@ -563,7 +563,7 @@ function populate_options() {
 
 		$value = maybe_serialize( sanitize_option( $option, $value ) );
 
-		$insert .= $wpdb->prepare( "(%s, %s, %s)", $option, $value, $autoload );
+		$insert .= $wpdb->prepare( '(%s, %s, %s)', $option, $value, $autoload );
 	}
 
 	if ( ! empty( $insert ) ) {

--- a/src/wp-admin/update.php
+++ b/src/wp-admin/update.php
@@ -163,7 +163,7 @@ if ( isset( $_GET['action'] ) ) {
 			wp_die( __( 'Only .zip archives may be uploaded.' ) );
 		}
 
-		$file_upload = new File_Upload_Upgrader('pluginzip', 'package');
+		$file_upload = new File_Upload_Upgrader( 'pluginzip', 'package' );
 
 		$title        = __( 'Upload Plugin' );
 		$parent_file  = 'plugins.php';
@@ -290,7 +290,7 @@ if ( isset( $_GET['action'] ) ) {
 			wp_die( __( 'Only .zip archives may be uploaded.' ) );
 		}
 
-		$file_upload = new File_Upload_Upgrader('themezip', 'package');
+		$file_upload = new File_Upload_Upgrader( 'themezip', 'package' );
 
 		$title        = __( 'Upload Theme' );
 		$parent_file  = 'themes.php';

--- a/src/wp-includes/version.php
+++ b/src/wp-includes/version.php
@@ -40,7 +40,7 @@ $cp_version = '1.7.2+dev';
  *
  * @global string $wp_version
  */
-$wp_version = '4.9.24';
+$wp_version = '4.9.25';
 
 /**
  * Holds the ClassicPress DB revision, increments when changes are made to the ClassicPress DB schema.


### PR DESCRIPTION
If we are going to release 1.7.3 for pushing changes to wp-cli in #268 we can also bump the WP version to 4.9.25 which now is the right one.

## Types of changes
- Bug fix

